### PR TITLE
Update project team and fix email in metadata

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,11 +36,12 @@ Documentation can be viewed at https://github-pages.ucl.ac.uk/dxh/
 
 Current members
 
-- Matt Graham ([matt-graham](https://github.com/matt-graham))
-- Krishnakumar Gopalakrishnan ([krishnakumarg1984](https://github.com/krishnakumarg1984))
-- Deepika Garg ([deepikagarg20](https://github.com/deepikagarg20))
-- Janosch Preuss ([janoschpreuss](https://github.com/janoschpreuss))
 - Erik Burman ([burmanerik](https://github.com/burmanerik))
+- Sam Cunliffe ([samcunliffe](https://github.com/samcunliffe))
+- Deepika Garg ([deepikagarg20](https://github.com/deepikagarg20))
+- Krishnakumar Gopalakrishnan ([krishnakumarg1984](https://github.com/krishnakumarg1984))
+- Matt Graham ([matt-graham](https://github.com/matt-graham))
+- Janosch Preuss ([janoschpreuss](https://github.com/janoschpreuss))
 
 Former members
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ requires = [
 
 [project]
 authors = [
-    {email = "arc-collab@ucl.ac.uk", name = "UCL Advanced Research Computing Centre Collaborations team"},
+    {email = "arc.collaborations@ucl.ac.uk", name = "UCL Advanced Research Computing Centre Collaborations team"},
 ]
 classifiers = [
     "Operating System :: POSIX",


### PR DESCRIPTION
Adds @samcunliffe to project team list 🎉  and sorts team alphabetically by surname (not that it matters...).

Also fixes another instance of incorrect ARC Collaborations email address not caught in #3.