### PR TITLE
Support DOLFINx 0.7 _and_ 0.6.

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,7 +63,8 @@ Centre for Advanced Research Computing, University College London
 
 ### Prerequisites
 
-Compatible with Python 3.9 and 3.10. [Requires DOLFINx v0.6.0 or above to be installed](https://github.com/FEniCS/dolfinx#installation).
+Compatible with Python 3.9 and 3.10.
+[We recommend DOLFINx v0.7.0 or above to be installed](https://github.com/FEniCS/dolfinx#installation) although we support v0.6.0 for now.
 
 ### Installation
 

--- a/src/dxh.py
+++ b/src/dxh.py
@@ -12,8 +12,16 @@ import dolfinx
 import matplotlib.pyplot as plt
 import numpy as np
 import ufl
-from dolfinx.fem import Constant, DirichletBCMetaClass, Function, FunctionSpace
+from dolfinx.fem import Constant, Function, FunctionSpace
 from dolfinx.fem.petsc import LinearProblem
+
+try:
+    # For compatibility with dolfinx@0.6 try initially import old
+    # DirichletBCMetaClass name
+    from dolfinx.fem import DirichletBCMetaClass as DirichletBC
+except ImportError:
+    from dolfinx.fem import DirichletBC
+
 from matplotlib.tri import Triangulation
 from mpi4py import MPI
 
@@ -297,7 +305,7 @@ def define_dirichlet_boundary_condition(
     boundary_indicator_function: Optional[
         Callable[[ufl.SpatialCoordinate], bool]
     ] = None,
-) -> DirichletBCMetaClass:
+) -> DirichletBC:
     """
     Define DOLFINx object representing Dirichlet boundary condition.
 

--- a/src/dxh.py
+++ b/src/dxh.py
@@ -136,7 +136,7 @@ def evaluate_function_at_points(
     tree = bb_tree(mesh, mesh.geometry.dim)
     cell_candidates = compute_collisions_points(tree, points)
     # TODO: when dropping support for DOLFINx v0.6, replace the above two lines
-    # with the following for tidier namespace use.
+    # with the full namespace `dolfinx.geometry` for tidier namespace use.
     #
     if not np.all(cell_candidates.offsets[1:] > 0):
         msg = "One or more points not within domain"

--- a/src/dxh.py
+++ b/src/dxh.py
@@ -1,7 +1,7 @@
 """Helper functions for DOLFINx."""
 
 from __future__ import annotations
-
+import warnings
 from typing import TYPE_CHECKING, Literal
 
 if TYPE_CHECKING:
@@ -16,11 +16,20 @@ from dolfinx.fem import Constant, Function, FunctionSpace
 from dolfinx.fem.petsc import LinearProblem
 
 try:
-    # For compatibility with dolfinx@0.6 try initially import old
-    # DirichletBCMetaClass name
-    from dolfinx.fem import DirichletBCMetaClass as DirichletBC
-except ImportError:
     from dolfinx.fem import DirichletBC
+except ImportError:
+    # Compatibility w dolfinx@0.6: try importing old DirichletBCMetaClass name.
+    from dolfinx.fem import DirichletBCMetaClass as DirichletBC
+
+try:
+    from dolfinx.geometry import bb_tree, compute_collisions_points
+except ImportError:
+    # Compatibility w dolfinx@0.6: if the new bb_tree function is not in DOLFINx
+    # then use the class constructor directly.
+    from dolfinx.geometry import BoundingBoxTree as bb_tree
+    from dolfinx.geometry import compute_collisions as compute_collisions_points
+
+
 
 from matplotlib.tri import Triangulation
 from mpi4py import MPI
@@ -29,6 +38,10 @@ if TYPE_CHECKING:
     from dolfinx.mesh import Mesh
     from matplotlib.colors import Colormap
     from numpy.typing import NDArray
+
+if dolfinx.__version__ < "0.7.0":
+    msg = "There is a new version of DOLFINx, and we'll probably stop supporting v0.6 soon. Please update FEniCSx as soon as you can."
+    warnings.warn(msg, DeprecationWarning)
 
 
 def get_matplotlib_triangulation_from_mesh(mesh: Mesh) -> Triangulation:
@@ -117,8 +130,13 @@ def evaluate_function_at_points(
         padded_points = np.zeros(points.shape[:-1] + (3,))
         padded_points[..., : points.shape[-1]] = points
         points = padded_points
-    tree = dolfinx.geometry.BoundingBoxTree(mesh, mesh.geometry.dim)
-    cell_candidates = dolfinx.geometry.compute_collisions(tree, points)
+    tree = bb_tree(mesh, mesh.geometry.dim)
+    cell_candidates = compute_collisions_points(tree, points)
+    # TODO: when dropping support for DOLFINx v0.6, replace the above two lines
+    # with the following for tidier namespace use.
+    #
+    # tree = dolfinx.geometry.bb_tree(mesh, mesh.geometry.dim)
+    # cell_candidates = dolfinx.geometry.compute_collisions_points(tree, points)
     if not np.all(cell_candidates.offsets[1:] > 0):
         msg = "One or more points not within domain"
         raise ValueError(msg)

--- a/src/dxh.py
+++ b/src/dxh.py
@@ -1,6 +1,7 @@
 """Helper functions for DOLFINx."""
 
 from __future__ import annotations
+
 import warnings
 from typing import TYPE_CHECKING, Literal
 
@@ -26,9 +27,8 @@ try:
 except ImportError:
     # Compatibility w dolfinx@0.6: if the new bb_tree function is not in DOLFINx
     # then use the class constructor directly.
-    from dolfinx.geometry import BoundingBoxTree as bb_tree
+    from dolfinx.geometry import BoundingBoxTree as bb_tree  # noqa: N813
     from dolfinx.geometry import compute_collisions as compute_collisions_points
-
 
 
 from matplotlib.tri import Triangulation
@@ -40,8 +40,11 @@ if TYPE_CHECKING:
     from numpy.typing import NDArray
 
 if dolfinx.__version__ < "0.7.0":
-    msg = "There is a new version of DOLFINx, and we'll probably stop supporting v0.6 soon. Please update FEniCSx as soon as you can."
-    warnings.warn(msg, DeprecationWarning)
+    msg = (
+        "There is a new version of DOLFINx, and we'll stop supporting v0.6 soon. "
+        "Please update FEniCSx as soon as you can."
+    )
+    warnings.warn(msg, DeprecationWarning, stacklevel=2)
 
 
 def get_matplotlib_triangulation_from_mesh(mesh: Mesh) -> Triangulation:
@@ -135,8 +138,6 @@ def evaluate_function_at_points(
     # TODO: when dropping support for DOLFINx v0.6, replace the above two lines
     # with the following for tidier namespace use.
     #
-    # tree = dolfinx.geometry.bb_tree(mesh, mesh.geometry.dim)
-    # cell_candidates = dolfinx.geometry.compute_collisions_points(tree, points)
     if not np.all(cell_candidates.offsets[1:] > 0):
         msg = "One or more points not within domain"
         raise ValueError(msg)

--- a/tests/test_dxh.py
+++ b/tests/test_dxh.py
@@ -363,19 +363,20 @@ def _unit_mesh_boundary_indicator_function(spatial_coordinate):
         for i in range(len(spatial_coordinate))
     )
 
+
 def _zero_vector(vector: dolfinx.la.Vector):
     """Fill the vector with zeros.
-    
+
     Accounts for the dolfinx 0.7 and 0.6 API differences.
 
-    TODO:
+    Todo:
         Remove this function and use `vector.array.fill(0.0)` directly in the
         code when dropping support for 0.6.
-    """ 
+    """
     try:
-        vector.array.fill(0.0) # dolfinx 0.7: underlying vector is numpy.ndarray.
+        vector.array.fill(0.0)  # dolfinx 0.7: underlying vector is numpy.ndarray.
     except AttributeError:
-        vector.set(0.0) # dolfinx 0.6: underlying vector is _cpp DOLFINx vector.
+        vector.set(0.0)  # dolfinx 0.6: underlying vector is _cpp DOLFINx vector.
 
 
 @pytest.mark.parametrize("number_cells_per_axis", [3, 10])

--- a/tests/test_dxh.py
+++ b/tests/test_dxh.py
@@ -10,6 +10,12 @@ from mpi4py import MPI
 
 import dxh
 
+try:
+    from dolfinx.fem import DirichletBC
+except ImportError:
+    # Compatibility w dolfinx@0.6: try importing old DirichletBCMetaClass name.
+    from dolfinx.fem import DirichletBCMetaClass as DirichletBC
+
 
 def _create_unit_mesh(spatial_dimension, number_cells_per_axis):
     if spatial_dimension == 1:
@@ -357,6 +363,20 @@ def _unit_mesh_boundary_indicator_function(spatial_coordinate):
         for i in range(len(spatial_coordinate))
     )
 
+def _zero_vector(vector: dolfinx.la.Vector):
+    """Fill the vector with zeros.
+    
+    Accounts for the dolfinx 0.7 and 0.6 API differences.
+
+    TODO:
+        Remove this function and use `vector.array.fill(0.0)` directly in the
+        code when dropping support for 0.6.
+    """ 
+    try:
+        vector.array.fill(0.0) # dolfinx 0.7: underlying vector is numpy.ndarray.
+    except AttributeError:
+        vector.set(0.0) # dolfinx 0.6: underlying vector is _cpp DOLFINx vector.
+
 
 @pytest.mark.parametrize("number_cells_per_axis", [3, 10])
 @pytest.mark.parametrize("spatial_dimension", [1, 2, 3])
@@ -377,7 +397,7 @@ def test_define_dirichlet_boundary_condition(
     function_space = dolfinx.fem.FunctionSpace(mesh, ("Lagrange", degree))
     if boundary_value_type == "function":
         boundary_value = dolfinx.fem.Function(function_space)
-        boundary_value.x.set(0.0)
+        _zero_vector(boundary_value.x)
     elif boundary_value_type == "constant":
         boundary_value = dolfinx.fem.Constant(mesh, 0.0)
     elif boundary_value_type == "float":
@@ -390,7 +410,7 @@ def test_define_dirichlet_boundary_condition(
         boundary_indicator_function=boundary_indicator_function,
         function_space=None if boundary_value_type == "function" else function_space,
     )
-    assert isinstance(boundary_condition, dolfinx.fem.DirichletBCMetaClass)
+    assert isinstance(boundary_condition, DirichletBC)
     assert boundary_condition.function_space == function_space._cpp_object
 
 


### PR DESCRIPTION
Re-purposing this stale PR to properly move to 0.7 maintaining backward support to 0.6. 

We could actually consider dumping 0.6 completely. It'd certainly mean cleaner code. As it is, I kept in the try-except blocks but did them the other way around. I.e. try to do it the 0.7 way first, and fallback on the 0.6 API.

## Solves

* #10 
* #13 

## Note for reviewers

My [comment down here 👇](https://github.com/UCL/dxh/pull/12#issuecomment-1705484789)  is now moot, because DOLFINx 0.7 is what we get from pip on the CI.