### PR TITLE
Coverage reporting and upload to codecov.

### DIFF
--- a/.github/codecov.yml
+++ b/.github/codecov.yml
@@ -1,0 +1,6 @@
+# Configures some options for codecov
+# https://docs.codecov.com/docs/codecov-yaml
+
+coverage:
+  precision: 1 # one decimal place
+  round: up

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -41,3 +41,7 @@ jobs:
           echo "tox_env=$TOX_ENV" >> "$GITHUB_ENV"
       - name: Test with tox
         run: tox -e ${{ env.tox_env }}
+      - name: Upload coverage reports to Codecov
+        uses: codecov/codecov-action@v3
+        env:
+          CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -2,6 +2,7 @@
 
 [![pre-commit](https://img.shields.io/badge/pre--commit-enabled-brightgreen?logo=pre-commit&logoColor=white)](https://github.com/pre-commit/pre-commit)
 [![Tests](https://github.com/UCL/dxh/actions/workflows/tests.yml/badge.svg)](https://github.com/UCL/dxh/actions/workflows/tests.yml)
+[![codecov](https://codecov.io/gh/UCL/dxh/graph/badge.svg?token=z0y0mDsvIx)](https://codecov.io/gh/UCL/dxh)
 [![Linting](https://github.com/UCL/dxh/actions/workflows/linting.yml/badge.svg)](https://github.com/UCL/dxh/actions/workflows/linting.yml)
 [![Documentation](https://github.com/UCL/dxh/actions/workflows/docs.yml/badge.svg)](https://github-pages.ucl.ac.uk/dxh/)
 [![Licence][licence-badge]](./LICENCE.md)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -169,7 +169,7 @@ conda_channels =
 
 [testenv:test-py{39,310}]
 commands =
-    pytest --cov
+    pytest --cov --cov-report=xml
 deps =
     pytest
     pytest-cov


### PR DESCRIPTION
Adds coverage reporting and upload of the report to codecov.io.
We'll get @codecov bot to comment on PRs and ensure we don't lose coverage (in the same way as we do for dxss).

## Blocked by

The tests (and therefore coverage upload) will fail until 

* #12 

... is merged.