### PR TITLE
Run tests against both DOLFINx v0.6 and v0.7.

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -13,9 +13,8 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version:
-          - "3.9"
-          - "3.10"
+        python-version: ["3.9", "3.10"]
+        dolfinx-version: ["0.6", "0.7"]
     steps:
       - name: Checkout source
         uses: actions/checkout@v3
@@ -36,8 +35,8 @@ jobs:
         # Workaround to map x.y Python version to form test-xy
         # https://stackoverflow.com/a/67248310
         run: |
-          RAW_TOX_ENV="test-py${{ matrix.python-version }}"
-          TOX_ENV=$(echo $RAW_TOX_ENV | sed 's/\.//')
+          RAW_TOX_ENV="test-py${{ matrix.python-version }}-dolfinx${{ matrix.dolfinx-version }}"
+          TOX_ENV=$(echo $RAW_TOX_ENV | sed 's/\.//' | sed 's/\.//' )
           echo "tox_env=$TOX_ENV" >> "$GITHUB_ENV"
       - name: Test with tox
         run: tox -e ${{ env.tox_env }}

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -36,7 +36,7 @@ jobs:
         # https://stackoverflow.com/a/67248310
         run: |
           RAW_TOX_ENV="test-py${{ matrix.python-version }}-dolfinx${{ matrix.dolfinx-version }}"
-          TOX_ENV=$(echo $RAW_TOX_ENV | sed 's/\.//' | sed 's/\.//' )
+          TOX_ENV=$(echo $RAW_TOX_ENV | sed 's/\.//g')
           echo "tox_env=$TOX_ENV" >> "$GITHUB_ENV"
       - name: Test with tox
         run: tox -e ${{ env.tox_env }}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -155,20 +155,20 @@ overrides."tool.coverage.paths.source".inline_arrays = false
 legacy_tox_ini = """
 [gh-actions]
 python =
-    3.9: test-py39
-    3.10: test-py310
+    3.9: test-py39-dolfinx{06,07}
+    3.10: test-py310-dolfinx{06,07}
 
 [testenv]
 conda_deps =
-    py{39,310}-fenics-dolfinx-0.6: fenics-dolfinx==0.6.0
-    py{39,310}-fenics-dolfinx-0.7: fenics-dolfinx==0.7.0
+    py{39,310}-dolfinx06: fenics-dolfinx==0.6
+    py{39,310}-dolfinx07: fenics-dolfinx==0.7
     fenics-ufl
     matplotlib
     numpy
 conda_channels =
     conda-forge
 
-[testenv:test-py{39,310}]
+[testenv:test-py{39,310}-dolfinx{06,07}]
 commands =
     pytest --cov --cov-report=xml
 deps =
@@ -186,8 +186,11 @@ deps =
 
 [tox]
 envlist =
-    test-py39
-    test-py310
+    test-py39-dolfinx06
+    test-py39-dolfinx07
+    test-py310-dolfinx06
+    test-py310-dolfinx07
+    docs
 isolated_build = true
 requires = tox-conda
 """

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -162,6 +162,7 @@ python =
 conda_deps =
     py{39,310}-dolfinx06: fenics-dolfinx==0.6
     py{39,310}-dolfinx07: fenics-dolfinx==0.7
+    docs: fenics-dolfinx==0.7
     fenics-ufl
     matplotlib
     numpy

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -160,7 +160,8 @@ python =
 
 [testenv]
 conda_deps =
-    fenics-dolfinx==0.6.0,0.7
+    py{39,310}-fenics-dolfinx-0.6: fenics-dolfinx==0.6.0
+    py{39,310}-fenics-dolfinx-0.7: fenics-dolfinx==0.7.0
     fenics-ufl
     matplotlib
     numpy

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -160,7 +160,7 @@ python =
 
 [testenv]
 conda_deps =
-    fenics-dolfinx
+    fenics-dolfinx==0.6.0,0.7
     fenics-ufl
     matplotlib
     numpy

--- a/tests/test_dxh.py
+++ b/tests/test_dxh.py
@@ -364,7 +364,7 @@ def _unit_mesh_boundary_indicator_function(spatial_coordinate):
     )
 
 
-def _zero_vector(vector: dolfinx.la.Vector):
+def _zero_vector(vector):
     """Fill the vector with zeros.
 
     Accounts for the dolfinx 0.7 and 0.6 API differences.


### PR DESCRIPTION
Now working, thanks mostly to @matt-graham's wisdom his reply to my standup on Friday.

Note that this is also _shown_ to be working via a genuine [test failure](https://github.com/UCL/dxh/actions/runs/6604683034/job/17939526872) with DOLFINx v0.6, at the penultimate commit [ddd06a3](https://github.com/UCL/dxh/pull/15/commits/ddd06a3074dcb2dac18e4b1fa8fc00241fee1a73). Due to a version-specific type annotation on `main`.

---

I argue that we probably **do** want to formally support v0.6 because that's what Deepika is using, and minimising breaking changes for her is worth our while, IMO.

---

A somewhat unimportant bonus is that our coverage goes up as we're now testing all the `except ImportError` codeblocks ☂️ 💜 .