### PR TITLE
Add support and tests for Python 3.11+

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -10,6 +10,7 @@ on:
 
 jobs:
   tests:
+    name: Tests with Python ${{ matrix.python-version }} and dolfinx ${{ matrix.dolfinx-version }}
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -13,8 +13,13 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.9", "3.10"]
+        python-version: ["3.9", "3.10", "3.11", "3.12"]
         dolfinx-version: ["0.6", "0.7"]
+        exclude:
+          - dolfinx-version: "0.6"
+            python-version: "3.11"
+          - dolfinx-version: "0.6"
+            python-version: "3.12"
     steps:
       - name: Checkout source
         uses: actions/checkout@v3

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -12,6 +12,7 @@ jobs:
   tests:
     runs-on: ubuntu-latest
     strategy:
+      fail-fast: false
       matrix:
         python-version: ["3.9", "3.10", "3.11", "3.12"]
         dolfinx-version: ["0.6", "0.7"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -164,13 +164,13 @@ python =
 
 [testenv]
 conda_deps =
-    dolfinx06: fenics-dolfinx==0.6
-    dolfinx07: fenics-dolfinx==0.7
-    docs: fenics-dolfinx==0.7
+    dolfinx06: fenics-dolfinx==0.6.*
+    dolfinx07: fenics-dolfinx==0.7.*
+    docs: fenics-dolfinx
 conda_channels =
     conda-forge
 
-[testenv:test-py{39,310}-dolfinx{06,07},test-py{311,312}-dolfinx07]
+[testenv:test-py{39,311,310,312}-dolfinx{06,07}]
 commands =
     pytest --cov --cov-report=xml
 deps =

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,6 +15,8 @@ classifiers = [
     "Programming Language :: Python :: 3 :: Only",
     "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
+    "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
     "Typing :: Typed",
 ]
 dependencies = [
@@ -45,7 +47,7 @@ optional-dependencies = {dev = [
     "twine",
 ]}
 readme = "README.md"
-requires-python = ">=3.9,<3.11"
+requires-python = ">=3.9"
 license.file = "LICENCE.md"
 urls.homepage = "https://github.com/UCL/dxh"
 
@@ -155,21 +157,20 @@ overrides."tool.coverage.paths.source".inline_arrays = false
 legacy_tox_ini = """
 [gh-actions]
 python =
-    3.9: test-py39-dolfinx{06,07}
-    3.10: test-py310-dolfinx{06,07}
+    3.9: py39
+    3.10: py310
+    3.11: py311
+    3.12: py312
 
 [testenv]
 conda_deps =
-    py{39,310}-dolfinx06: fenics-dolfinx==0.6
-    py{39,310}-dolfinx07: fenics-dolfinx==0.7
+    dolfinx06: fenics-dolfinx==0.6
+    dolfinx07: fenics-dolfinx==0.7
     docs: fenics-dolfinx==0.7
-    fenics-ufl
-    matplotlib
-    numpy
 conda_channels =
     conda-forge
 
-[testenv:test-py{39,310}-dolfinx{06,07}]
+[testenv:test-py{39,310}-dolfinx{06,07},test-py{311,312}-dolfinx07]
 commands =
     pytest --cov --cov-report=xml
 deps =
@@ -187,10 +188,8 @@ deps =
 
 [tox]
 envlist =
-    test-py39-dolfinx06
-    test-py39-dolfinx07
-    test-py310-dolfinx06
-    test-py310-dolfinx07
+    test-py{39,310}-dolfinx{06,07}
+    test-py{311,312}-dolfinx07
     docs
 isolated_build = true
 requires = tox-conda


### PR DESCRIPTION
Part of #17 (not linking as we may still want to drop Python 3.9 support in a separate PR)

Relaxes `requires-python` specifier to allow using Python 3.11+ and updates tests workflow to test across Python 3.11 and 3.12 with dolfinx v0.7.