### PR TITLE
Drop Python 3.9 support and add DOLFINx v0.8 support

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -23,7 +23,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v4
         with:
-          python-version: 3.9
+          python-version: 3.x
           cache: "pip"
           cache-dependency-path: "pyproject.toml"
       - name: Install tox

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -15,8 +15,8 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.9", "3.10", "3.11", "3.12"]
-        dolfinx-version: ["0.6", "0.7"]
+        python-version: ["3.10", "3.11", "3.12"]
+        dolfinx-version: ["0.6", "0.7", "0.8"]
         exclude:
           - dolfinx-version: "0.6"
             python-version: "3.11"

--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ Centre for Advanced Research Computing, University College London
 
 ### Prerequisites
 
-Compatible with Python 3.9 and 3.10.
+Compatible with Python 3.10 and above.
 [We recommend DOLFINx v0.7.0 or above to be installed](https://github.com/FEniCS/dolfinx#installation) although we support v0.6.0 for now.
 
 ### Installation
@@ -98,13 +98,13 @@ Tests can be run across all compatible Python versions in isolated environments 
 tox
 ```
 
-from the root of the repository, or to run tests with Python 3.9 specifically run
+from the root of the repository, or to run tests with Python 3.10 specifically run
 
 ```sh
-tox -e test-py39
+tox -e test-py310
 ```
 
-substituting `py39` for `py310` to run tests with Python 3.10.
+substituting `py310` for `py311` or `py312` to run tests with Python 3.11 or 3.12 respectively.
 
 To run tests manually in a Python environment with `pytest` installed run
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,7 +13,6 @@ classifiers = [
     "Operating System :: POSIX",
     "Programming Language :: Python :: 3",
     "Programming Language :: Python :: 3 :: Only",
-    "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
@@ -47,7 +46,7 @@ optional-dependencies = {dev = [
     "twine",
 ]}
 readme = "README.md"
-requires-python = ">=3.9"
+requires-python = ">=3.10"
 license.file = "LICENCE.md"
 urls.homepage = "https://github.com/UCL/dxh"
 
@@ -130,7 +129,7 @@ select = [
     "W",
     "YTT",
 ]
-target-version = "py39"
+target-version = "py310"
 isort.known-first-party = [
     "dxh",
 ]
@@ -157,7 +156,6 @@ overrides."tool.coverage.paths.source".inline_arrays = false
 legacy_tox_ini = """
 [gh-actions]
 python =
-    3.9: py39
     3.10: py310
     3.11: py311
     3.12: py312
@@ -166,11 +164,12 @@ python =
 conda_deps =
     dolfinx06: fenics-dolfinx==0.6.*
     dolfinx07: fenics-dolfinx==0.7.*
+    dolfinx08: fenics-dolfinx==0.8.*
     docs: fenics-dolfinx
 conda_channels =
     conda-forge
 
-[testenv:test-py{39,311,310,312}-dolfinx{06,07}]
+[testenv:test-py{310,311,312}-dolfinx{06,07,08}]
 commands =
     pytest --cov --cov-report=xml
 deps =
@@ -188,8 +187,8 @@ deps =
 
 [tox]
 envlist =
-    test-py{39,310}-dolfinx{06,07}
-    test-py{311,312}-dolfinx07
+    test-py310-dolfinx{06,07,08}
+    test-py{311,312}-dolfinx{07,08}
     docs
 isolated_build = true
 requires = tox-conda

--- a/src/dxh.py
+++ b/src/dxh.py
@@ -6,8 +6,7 @@ import warnings
 from typing import TYPE_CHECKING, Literal
 
 if TYPE_CHECKING:
-    from collections.abc import Sequence
-    from typing import Callable, Optional, Union
+    from collections.abc import Callable, Sequence
 
 import dolfinx
 import matplotlib.pyplot as plt
@@ -75,10 +74,9 @@ def get_matplotlib_triangulation_from_mesh(mesh: Mesh) -> Triangulation:
 
 
 def project_expression_on_function_space(
-    expression: Union[
-        ufl.core.expr.Expr,
-        Callable[[ufl.SpatialCoordinate], ufl.core.expr.Expr],
-    ],
+    expression: (
+        ufl.core.expr.Expr | Callable[[ufl.SpatialCoordinate], ufl.core.expr.Expr]
+    ),
     function_space: ufl.FunctionSpace,
 ) -> Function:
     """
@@ -154,7 +152,7 @@ def evaluate_function_at_points(
 
 
 def _preprocess_functions(
-    functions: Union[Function, Sequence[Function], dict[str, Function]],
+    functions: Function | Sequence[Function] | dict[str, Function],
 ) -> list[tuple[str, Function]]:
     if isinstance(functions, Function):
         return [(functions.name, functions)]
@@ -165,9 +163,9 @@ def _preprocess_functions(
 
 
 def plot_1d_functions(
-    functions: Union[Function, Sequence[Function], dict[str, Function]],
+    functions: Function | Sequence[Function] | dict[str, Function],
     *,
-    points: Optional[NDArray[np.float64]] = None,
+    points: NDArray[np.float64] | None = None,
     axis_size: tuple[float, float] = (5.0, 5.0),
     arrangement: Literal["horizontal", "vertical", "stacked"] = "horizontal",
 ) -> plt.Figure:
@@ -226,13 +224,13 @@ def plot_1d_functions(
 
 
 def plot_2d_functions(
-    functions: Union[Function, list[Function], dict[str, Function]],
+    functions: Function | list[Function] | dict[str, Function],
     *,
     plot_type: Literal["pcolor", "surface"] = "pcolor",
     axis_size: tuple[float, float] = (5.0, 5.0),
-    colormap: Union[str, Colormap, None] = None,
+    colormap: str | Colormap | None = None,
     show_colorbar: bool = True,
-    triangulation_color: Union[str, tuple[float, float, float], None] = None,
+    triangulation_color: str | tuple[float, float, float] | None = None,
     arrangement: Literal["horizontal", "vertical"] = "horizontal",
 ) -> plt.Figure:
     """
@@ -281,7 +279,11 @@ def plot_2d_functions(
         raise ValueError(msg)
     subplot_kw = {"projection": "3d"} if plot_type == "surface" else {}
     fig, axes = plt.subplots(n_rows, n_cols, figsize=figsize, subplot_kw=subplot_kw)
-    for ax, (label, function) in zip(np.atleast_1d(axes), label_and_functions):
+    for ax, (label, function) in zip(
+        np.atleast_1d(axes),
+        label_and_functions,
+        strict=True,
+    ):
         mesh = function.function_space.mesh
         if mesh.topology.dim != 2:
             msg = "Only two-dimensional spatial domains are supported"
@@ -321,12 +323,10 @@ def plot_2d_functions(
 
 
 def define_dirichlet_boundary_condition(
-    boundary_value: Union[Function, Constant, float],
-    function_space: Optional[FunctionSpace] = None,
+    boundary_value: Function | Constant | float,
+    function_space: FunctionSpace | None = None,
     *,
-    boundary_indicator_function: Optional[
-        Callable[[ufl.SpatialCoordinate], bool]
-    ] = None,
+    boundary_indicator_function: Callable[[ufl.SpatialCoordinate], bool] | None = None,
 ) -> DirichletBC:
     """
     Define DOLFINx object representing Dirichlet boundary condition.
@@ -382,11 +382,11 @@ def define_dirichlet_boundary_condition(
 
 def error_norm(
     function_1: dolfinx.fem.Function,
-    function_or_expression_2: Union[
-        dolfinx.fem.Function,
-        ufl.core.expr.Expr,
-        Callable[[ufl.SpatialCoordinate], ufl.core.expr.Expr],
-    ],
+    function_or_expression_2: (
+        dolfinx.fem.Function
+        | ufl.core.expr.Expr
+        | Callable[[ufl.SpatialCoordinate], ufl.core.expr.Expr]
+    ),
     degree_raise: int = 3,
     norm_order: Literal[1, 2, "inf-dof"] = 2,
 ) -> float:

--- a/src/dxh.py
+++ b/src/dxh.py
@@ -449,6 +449,9 @@ def error_norm(
     """
     # Create raised degree function space with same element as for original function_1
     original_degree = function_1.function_space.ufl_element().degree
+    if callable(original_degree):
+        # Depending on Basix version degree may be an accesor method or attribute
+        original_degree = original_degree()
     family = function_1.function_space.ufl_element().family_name
     mesh = function_1.function_space.mesh
     raised_degree_function_space = functionspace(


### PR DESCRIPTION
Adds DOLFINx v0.8 to test matrix and updates usages of DOLFINx API to ensure compatibility across versions v0.6 through v0.8. 

Also drops Python 3.9 support on the basis this is now > 3 years old and out of both NEP29 and SPEC0 recommended support windows, and our test matrix is getting a bit unwieldy.

Also updates our type hints to use `|` in place of explicit `Union` or `Optional` where appropriate, and adds `strict=True` argument to a call to `zip`.