### PR TITLE
Passing through HOME environment variable in tox environments

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -168,6 +168,7 @@ conda_deps =
     docs: fenics-dolfinx
 conda_channels =
     conda-forge
+passenv = HOME
 
 [testenv:test-py{310,311,312}-dolfinx{06,07,08}]
 commands =


### PR DESCRIPTION
We seem to be getting intermittent failures in the `tox` `test` and `docs` environments due to the lack of a `HOME` variable being set with the tox environment which is causing an error on importing `dxh` (and thus importing some `dolfinx` modules):

```
[fv-az881-524:03933] Error: Unable to get the user home directory
[fv-az881-524:03933] Error: Unable to get the user home directory
--------------------------------------------------------------------------
It looks like opal_init failed for some reason; your parallel process is
likely to abort.  There are many reasons that a parallel process can
fail during opal_init; some of which are due to configuration or
environment problems.  This failure appears to be an internal failure;
here's some additional information (which may only be relevant to an
Open MPI developer):

  mca_base_var_init failed
  --> Returned value -1 instead of OPAL_SUCCESS
--------------------------------------------------------------------------
--------------------------------------------------------------------------
It looks like MPI_INIT failed for some reason; your parallel process is
likely to abort.  There are many reasons that a parallel process can
fail during MPI_INIT; some of which are due to configuration or environment
problems.  This failure appears to be an internal failure; here's some
additional information (which may only be relevant to an Open MPI
developer):

  ompi_mpi_instance_init: opal_init_util failed
  --> Returned "Error" (-1) instead of "Success" (0)
--------------------------------------------------------------------------
--------------------------------------------------------------------------
It looks like MPI_INIT failed for some reason; your parallel process is
likely to abort.  There are many reasons that a parallel process can
fail during MPI_INIT; some of which are due to configuration or environment
problems.  This failure appears to be an internal failure; here's some
additional information (which may only be relevant to an Open MPI
developer):

  ompi_mpi_init: ompi_mpi_instance_init failed
  --> Returned "Error" (-1) instead of "Success" (0)
--------------------------------------------------------------------------
*** An error occurred in MPI_Init_thread
*** on a NULL communicator
*** MPI_ERRORS_ARE_FATAL (processes in this communicator will now abort,
***    and MPI will try to terminate your MPI job as well)
[fv-az881-524:03933] Local abort before MPI_INIT completed completed successfully, but am not able to aggregate error messages, and not able to guarantee that all other processes were killed!
```

From testing locally, setting `passenv = HOME` in the tox configuration to pass through the `HOME` environment variable seems to fix the issue.